### PR TITLE
[Misc] fix typos and command errors in documentation

### DIFF
--- a/resources/doc/app_runner_dataset.md
+++ b/resources/doc/app_runner_dataset.md
@@ -69,7 +69,7 @@ dataset/
 ## Run
 First activate the conda environment
 ```
-conda activcate dualmap
+conda activate dualmap
 ```
 
 Then, navigate to the repository root and run the application:

--- a/resources/doc/app_simulation.md
+++ b/resources/doc/app_simulation.md
@@ -52,7 +52,7 @@ Next, open a **new terminal** and start the Habitat Data Collector:
 cd <Path to >/habitat-data-collector
 conda activate habitat_data_collector
 
-source source /opt/ros/humble/setup.bash
+source /opt/ros/humble/setup.bash
 python -m habitat_data_collector.main
 ```
 
@@ -115,7 +115,7 @@ Next, open a **new terminal** and start the Habitat Data Collector to trigger th
 cd <Path to >/habitat-data-collector
 conda activate habitat_data_collector
 
-source source /opt/ros/humble/setup.bash
+source /opt/ros/humble/setup.bash
 python -m habitat_data_collector.main
 ```
 You can also use a `rosbag` to trigger the mapping.

--- a/resources/doc/data_replica_scannet.md
+++ b/resources/doc/data_replica_scannet.md
@@ -85,7 +85,7 @@ If you are using ScanNet (20 classes), the semantic annotations are stored in fi
 
 ```
 <PATH TO ScanNet200>/
-├── tarin/
+├── train/
 └── val/
     ├── scene0011_00.ply
     ├── scene0050_00.ply


### PR DESCRIPTION
- Fix 'activcate' typo in app_runner_dataset.md
- Fix duplicate 'source' commands in app_simulation.md
- Fix 'tarin' typo in data_replica_scannet.md