### PR TITLE
[Bugfix] Make depth encoding dynamic instead of hardcoed 16UC1

### DIFF
--- a/applications/utils/runner_ros1.py
+++ b/applications/utils/runner_ros1.py
@@ -79,8 +79,7 @@ class RunnerROS1(RunnerROSBase):
             depth_img = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="passthrough")
 
         depth_factor = getattr(self.dataset_cfg, 'depth_factor', 1000.0)
-        depth_img = depth_img.astype(np.float32) / depth_factor
-        depth_img = np.expand_dims(depth_img, axis=-1)
+        depth_img = self.process_depth_image(depth_img, depth_factor)
 
         translation = np.array(
             [

--- a/applications/utils/runner_ros1.py
+++ b/applications/utils/runner_ros1.py
@@ -76,7 +76,7 @@ class RunnerROS1(RunnerROSBase):
             depth_img = self.decompress_image(depth_msg.data, is_depth=True)
         else:
             rgb_img = self.bridge.imgmsg_to_cv2(rgb_msg, desired_encoding="rgb8")
-            depth_img = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="16UC1")
+            depth_img = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="passthrough")
 
         depth_factor = getattr(self.dataset_cfg, 'depth_factor', 1000.0)
         depth_img = depth_img.astype(np.float32) / depth_factor

--- a/applications/utils/runner_ros2.py
+++ b/applications/utils/runner_ros2.py
@@ -90,7 +90,7 @@ class RunnerROS2(Node, RunnerROSBase):
             depth_img = self.decompress_image(depth_msg.data, is_depth=True)
         else:
             rgb_img = self.bridge.imgmsg_to_cv2(rgb_msg, desired_encoding="rgb8")
-            depth_img = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="16UC1")
+            depth_img = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="passthrough")
 
         depth_factor = getattr(self.dataset_cfg, 'depth_factor', 1000.0)
         depth_img = depth_img.astype(np.float32) / depth_factor

--- a/applications/utils/runner_ros2.py
+++ b/applications/utils/runner_ros2.py
@@ -93,8 +93,7 @@ class RunnerROS2(Node, RunnerROSBase):
             depth_img = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="passthrough")
 
         depth_factor = getattr(self.dataset_cfg, 'depth_factor', 1000.0)
-        depth_img = depth_img.astype(np.float32) / depth_factor
-        depth_img = np.expand_dims(depth_img, axis=-1)
+        depth_img = self.process_depth_image(depth_img, depth_factor)
 
         translation = np.array(
             [

--- a/config/data_config/ros/car.yaml
+++ b/config/data_config/ros/car.yaml
@@ -6,7 +6,9 @@ ros_topics:
   odom: "/fastlio_odom"
   camera_info: "/orbbec_camera/color/camera_info"
 
-# Depth factor for converting depth values from millimeters to meters
+# Depth factor: divisor to convert depth values to meters
+# - For 16UC1 (uint16) depth in millimeters (e.g., RealSense, Orbbec): use 1000.0
+# - For 32FC1 (float32) depth in meters (e.g., Isaac Sim, Gazebo): use 1.0
 depth_factor: 1000.0
 
 # We use camera to lidar as default extrinsics

--- a/config/data_config/ros/car_online.yaml
+++ b/config/data_config/ros/car_online.yaml
@@ -7,7 +7,9 @@ ros_topics:
   odom: "/fastlio_odom"
   camera_info: "/orbbec_camera/color/camera_info"
 
-# Depth factor for converting depth values from millimeters to meters
+# Depth factor: divisor to convert depth values to meters
+# - For 16UC1 (uint16) depth in millimeters (e.g., RealSense, Orbbec): use 1000.0
+# - For 32FC1 (float32) depth in meters (e.g., Isaac Sim, Gazebo): use 1.0
 depth_factor: 1000.0
 
 # We use camera to lidar as default extrinsics

--- a/config/data_config/ros/clio.yaml
+++ b/config/data_config/ros/clio.yaml
@@ -5,7 +5,9 @@ ros_topics:
   depth: "/dominic/forward/depth/image_rect_raw"
   odom: "/dominic/forward/colmap_odom"
 
-# Depth factor for converting depth values from millimeters to meters
+# Depth factor: divisor to convert depth values to meters
+# - For 16UC1 (uint16) depth in millimeters (e.g., RealSense, Orbbec): use 1000.0
+# - For 32FC1 (float32) depth in meters (e.g., Isaac Sim, Gazebo): use 1.0
 depth_factor: 1000.0
 
 intrinsic:

--- a/config/data_config/ros/lab_device_online_ros1.yaml
+++ b/config/data_config/ros/lab_device_online_ros1.yaml
@@ -6,7 +6,9 @@ ros_topics:
   odom: "/fastlio_odom"
   camera_info: "/orbbec_camera/color/camera_info"
 
-# Depth factor for converting depth values from millimeters to meters
+# Depth factor: divisor to convert depth values to meters
+# - For 16UC1 (uint16) depth in millimeters (e.g., RealSense, Orbbec): use 1000.0
+# - For 32FC1 (float32) depth in meters (e.g., Isaac Sim, Gazebo): use 1.0
 depth_factor: 1000.0
 
 # We use camera to lidar as default extrinsics

--- a/config/data_config/ros/lab_device_online_ros2.yaml
+++ b/config/data_config/ros/lab_device_online_ros2.yaml
@@ -6,7 +6,9 @@ ros_topics:
   odom: "/ros2/Odometry"
   camera_info: "/ros2/color/camera_info"
 
-# Depth factor for converting depth values from millimeters to meters
+# Depth factor: divisor to convert depth values to meters
+# - For 16UC1 (uint16) depth in millimeters (e.g., RealSense, Orbbec): use 1000.0
+# - For 32FC1 (float32) depth in meters (e.g., Isaac Sim, Gazebo): use 1.0
 depth_factor: 1000.0
 
 # We use camera to lidar as default extrinsics

--- a/config/data_config/ros/self_collected.yaml
+++ b/config/data_config/ros/self_collected.yaml
@@ -6,7 +6,9 @@ ros_topics:
   odom: "/camera/pose"
   camera_info: "/camera_info"
 
-# Depth factor for converting depth values from millimeters to meters
+# Depth factor: divisor to convert depth values to meters
+# - For 16UC1 (uint16) depth in millimeters (e.g., RealSense, Orbbec): use 1000.0
+# - For 32FC1 (float32) depth in meters (e.g., Isaac Sim, Gazebo): use 1.0
 depth_factor: 1000.0
 
 intrinsic:


### PR DESCRIPTION
This PR replaces the hardcoded 16UC1 depth encoding in the RunnerROS2 class with a dynamic "passthrough" approach. This change allows the system to natively support 32-bit floating-point depth data (32FC1) commonly used in high-fidelity simulators like NVIDIA Isaac Sim.

Related Issue: #43 